### PR TITLE
Extractor: Destination is fs.Dir, not []const u8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 - 2024-01-21
+### Added
+- `Iterator.extractDir` and `Archive.extractDir` to extract to an open `std.fs.Dir`.
+
+### Changed
+- Extractor now operates on `std.fs.Dir` instead of `[]const u8`.
+  As a result of this change, `Extractor.init` may return an error,
+  and a call to the new `Extractor.deinit` method is required for cleanup.
+
 ## 0.2.1 - 2024-01-01
 ### Fixed
 - Fix build.zig.zon for release.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ into your build.zig.zon.
 (This requires at least Zig 0.11.)
 
 ```bash
-zig fetch --save "https://github.com/abhinav/txtar.zig/archive/0.2.1.tar.gz"
+zig fetch --save "https://github.com/abhinav/txtar.zig/archive/0.3.0.tar.gz"
 ```
 
 Then, import the dependency in your build.zig:

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
     .name = "txtar",
-    .version = "0.2.1",
+    .version = "0.3.0",
     .paths = .{"."},
 }

--- a/src/Archive.zig
+++ b/src/Archive.zig
@@ -75,7 +75,19 @@ pub fn deinit(self: Archive) void {
 /// Paths in the archive are relative to the destination directory.
 /// They are not allowed to escape the destination directory with use of `../`.
 pub fn extract(self: Archive, alloc: std.mem.Allocator, dest: []const u8) !void {
-    const extractor = Extractor.init(alloc, dest);
+    var dir = try std.fs.cwd().makeOpenPath(dest, .{});
+    defer dir.close();
+
+    return self.extractDir(alloc, dir);
+}
+
+/// Extracts all files in the Archive to the given directory.
+///
+/// Paths in the archive are relative to the destination directory.
+/// They are not allowed to escape the destination directory with use of `../`.
+pub fn extractDir(self: Archive, alloc: std.mem.Allocator, dir: std.fs.Dir) !void {
+    const extractor = try Extractor.init(alloc, dir);
+    defer extractor.deinit();
 
     for (self.files.items()) |file| {
         try extractor.writeFile(file);

--- a/src/txtar.zig
+++ b/src/txtar.zig
@@ -99,7 +99,9 @@
 //! Whereas with `Extractor`, you must manually iterate over the files:
 //!
 //! ```
-//! var extractor = try txtar.Extractor.init(allocator, "path/to/dir");
+//! const extractor = try txtar.Extractor.init(allocator, dir);
+//! defer extractor.deinit();
+//!
 //! try extractor.writeFile(txtar.File{ ... });
 //! try extractor.writeFile(txtar.File{ ... });
 //! ```


### PR DESCRIPTION
Changes Extractor to accept and operate on an open `fs.Dir`,
instead of string file paths.

Adds `extractDir` methods to Archive and Iterator
to take advantage of this functionality.
