### PR TITLE
all: Rename functions and methods to snake_case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Functions and methods are all now `snake_case`.
+
 ## 0.3.0 - 2024-01-21
 ### Added
 - `Iterator.extractDir` and `Archive.extractDir` to extract to an open `std.fs.Dir`.

--- a/src/Archive.zig
+++ b/src/Archive.zig
@@ -78,19 +78,19 @@ pub fn extract(self: Archive, alloc: std.mem.Allocator, dest: []const u8) !void 
     var dir = try std.fs.cwd().makeOpenPath(dest, .{});
     defer dir.close();
 
-    return self.extractDir(alloc, dir);
+    return self.extract_dir(alloc, dir);
 }
 
 /// Extracts all files in the Archive to the given directory.
 ///
 /// Paths in the archive are relative to the destination directory.
 /// They are not allowed to escape the destination directory with use of `../`.
-pub fn extractDir(self: Archive, alloc: std.mem.Allocator, dir: std.fs.Dir) !void {
+pub fn extract_dir(self: Archive, alloc: std.mem.Allocator, dir: std.fs.Dir) !void {
     const extractor = try Extractor.init(alloc, dir);
     defer extractor.deinit();
 
     for (self.files.items()) |file| {
-        try extractor.writeFile(file);
+        try extractor.write_file(file);
     }
 }
 

--- a/src/Extractor.zig
+++ b/src/Extractor.zig
@@ -11,7 +11,7 @@
 //! For example:
 //!
 //! ```
-//! extractor.writeFile(txtar.File{
+//! extractor.write_file(txtar.File{
 //!   .name = "../foo.txt",
 //!   .contents = "...",
 //! });
@@ -63,10 +63,10 @@ const FSError = std.os.MakeDirError || std.fs.File.OpenError || std.fs.File.Writ
 ///
 /// If the file attempts to traverse outside the destination directory,
 /// returns error.PathTraversal.
-pub fn writeFile(self: *const Extractor, f: File) WriteError!void {
+pub fn write_file(self: *const Extractor, f: File) WriteError!void {
     const resolved_path = try std.fs.path.resolve(self.allocator, &.{ self.dir_path, f.name });
     defer self.allocator.free(resolved_path);
-    if (!isDescendant(self.dir_path, resolved_path)) return error.PathTraversal;
+    if (!is_descendant(self.dir_path, resolved_path)) return error.PathTraversal;
 
     if (std.fs.path.dirname(f.name)) |parent_dir| {
         try self.dir.makePath(parent_dir);
@@ -77,7 +77,7 @@ pub fn writeFile(self: *const Extractor, f: File) WriteError!void {
     try file.writer().writeAll(f.contents);
 }
 
-test "writeFile allocation error" {
+test "write_file allocation error" {
     const allocator = std.testing.failing_allocator;
 
     var temp_dir = std.testing.tmpDir(.{});
@@ -87,7 +87,7 @@ test "writeFile allocation error" {
     try std.testing.expectError(error.OutOfMemory, got);
 }
 
-test "writeFile traversal error" {
+test "write_file traversal error" {
     const allocator = std.testing.allocator;
 
     var temp_dir = std.testing.tmpDir(.{});
@@ -103,11 +103,11 @@ test "writeFile traversal error" {
         "../../../foo",
     };
     for (tests) |name| {
-        const got = extractor.writeFile(.{
+        const got = extractor.write_file(.{
             .name = name,
             .contents = "quux",
         });
-        errdefer std.debug.print("writeFile({s}) should fail\n", .{name});
+        errdefer std.debug.print("write_file({s}) should fail\n", .{name});
 
         try std.testing.expectError(error.PathTraversal, got);
     }
@@ -115,7 +115,7 @@ test "writeFile traversal error" {
 
 // Reports whether child is a descendant of parent.
 // Must not be equal to parent.
-fn isDescendant(p: []const u8, child: []const u8) bool {
+fn is_descendant(p: []const u8, child: []const u8) bool {
     // Drop trailing slash from parent.
     const parent = if (p.len > 0 and p[p.len - 1] == std.fs.path.sep)
         p[0 .. p.len - 1]
@@ -130,7 +130,7 @@ fn isDescendant(p: []const u8, child: []const u8) bool {
         child[parent.len] == std.fs.path.sep;
 }
 
-test "isDescendant" {
+test "is_descendant" {
     const sep = std.fs.path.sep_str;
 
     const tests = [_]struct {
@@ -144,8 +144,8 @@ test "isDescendant" {
     };
 
     for (tests) |tt| {
-        const got = isDescendant(tt.parent, tt.child);
-        errdefer std.debug.print("isDescendant({s}, {s}) should be {}\n", .{ tt.parent, tt.child, tt.want });
+        const got = is_descendant(tt.parent, tt.child);
+        errdefer std.debug.print("is_descendant({s}, {s}) should be {}\n", .{ tt.parent, tt.child, tt.want });
         try std.testing.expectEqual(got, tt.want);
     }
 }

--- a/src/Iterator.zig
+++ b/src/Iterator.zig
@@ -72,7 +72,7 @@ pub fn extract(self: *Iterator, alloc: std.mem.Allocator, dest: []const u8) !voi
     var dir = try std.fs.cwd().makeOpenPath(dest, .{});
     defer dir.close();
 
-    return self.extractDir(alloc, dir);
+    return self.extract_dir(alloc, dir);
 }
 
 /// Extracts the remaining contents of an Iterator to a directory,
@@ -80,12 +80,12 @@ pub fn extract(self: *Iterator, alloc: std.mem.Allocator, dest: []const u8) !voi
 ///
 /// Paths in the archive are relative to the destination directory.
 /// They are not allowed to escape the destination directory with use of `../`.
-pub fn extractDir(self: *Iterator, alloc: std.mem.Allocator, dir: std.fs.Dir) !void {
+pub fn extract_dir(self: *Iterator, alloc: std.mem.Allocator, dir: std.fs.Dir) !void {
     const extractor = try Extractor.init(alloc, dir);
     defer extractor.deinit();
 
     while (self.next()) |file| {
-        try extractor.writeFile(file);
+        try extractor.write_file(file);
     }
 }
 

--- a/src/format.zig
+++ b/src/format.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 const File = @import("./File.zig");
 
 /// Formatter writes txtar files to a writer of the given type.
-/// Use `newFormatter` to construct a Formatter from a writer with a known type.
+/// Use `new_formatter` to construct a Formatter from a writer with a known type.
 pub fn Formatter(comptime Writer: type) type {
     return struct {
         /// Error type returned by the Formatter.
@@ -19,7 +19,7 @@ pub fn Formatter(comptime Writer: type) type {
         /// Comment, if non-null, is written at the top of the file.
         pub fn init(w: Writer, comment: ?[]const u8) Error!Self {
             if (comment) |c| if (c.len > 0) {
-                try printEnsureNL(w, c);
+                try print_ensure_nl(w, c);
             };
 
             return .{ .writer = w };
@@ -33,12 +33,12 @@ pub fn Formatter(comptime Writer: type) type {
         /// Note that the formatter does not sanitize the file name.
         /// If it contains directory traversal elements like "../",
         /// they'll be written to the txtar file as-is.
-        pub fn writeFile(self: *Self, f: File) Error!void {
+        pub fn write_file(self: *Self, f: File) Error!void {
             try self.writer.print("-- {s} --\n", .{f.name});
-            try printEnsureNL(self.writer, f.contents);
+            try print_ensure_nl(self.writer, f.contents);
         }
 
-        fn printEnsureNL(w: Writer, s: []const u8) Error!void {
+        fn print_ensure_nl(w: Writer, s: []const u8) Error!void {
             try w.print("{s}", .{s});
             if (s.len == 0 or s[s.len - 1] != '\n') {
                 try w.print("\n", .{});
@@ -57,7 +57,7 @@ test "file tests" {
         const w = buf.writer();
         var formatter = try Formatter(@TypeOf(w)).init(w, tt.comment);
         for (tt.files) |f| {
-            try formatter.writeFile(f);
+            try formatter.write_file(f);
         }
 
         const want_src = tt.canonical_src orelse tt.src;

--- a/src/txtar.zig
+++ b/src/txtar.zig
@@ -68,12 +68,12 @@
 //!
 //! ## Writing txtar files
 //!
-//! Use `newFormatter` to write txtar files to a writer.
+//! Use `new_formatter` to write txtar files to a writer.
 //!
 //! ```
 //! var file: std.fs.File = // ...
-//! var f = try txtar.newFormatter(file.writer(), "This is a comment.");
-//! try f.writeFile(.{
+//! var f = try txtar.new_formatter(file.writer(), "This is a comment.");
+//! try f.write_file(.{
 //!    .name = "foo/bar.txt",
 //!    .contents = "Hello, world!\n",
 //! });
@@ -102,8 +102,8 @@
 //! const extractor = try txtar.Extractor.init(allocator, dir);
 //! defer extractor.deinit();
 //!
-//! try extractor.writeFile(txtar.File{ ... });
-//! try extractor.writeFile(txtar.File{ ... });
+//! try extractor.write_file(txtar.File{ ... });
+//! try extractor.write_file(txtar.File{ ... });
 //! ```
 
 const std = @import("std");
@@ -117,17 +117,17 @@ pub const Extractor = @import("./Extractor.zig");
 /// Constructs a Formatter from a writer with a known type.
 ///
 /// This can be more convenient than instantiating the Formatter type directly.
-pub fn newFormatter(writer: anytype, comment: ?[]const u8) !Formatter(@TypeOf(writer)) {
+pub fn new_formatter(writer: anytype, comment: ?[]const u8) !Formatter(@TypeOf(writer)) {
     return try Formatter(@TypeOf(writer)).init(writer, comment);
 }
 
-test newFormatter {
+test new_formatter {
     var buf = std.ArrayList(u8).init(std.testing.allocator);
     defer buf.deinit();
 
-    var f = try newFormatter(buf.writer(), "comment");
-    try f.writeFile(.{ .name = "foo.txt", .contents = "foo" });
-    try f.writeFile(.{ .name = "bar.txt", .contents = "bar\n" });
+    var f = try new_formatter(buf.writer(), "comment");
+    try f.write_file(.{ .name = "foo.txt", .contents = "foo" });
+    try f.write_file(.{ .name = "bar.txt", .contents = "bar\n" });
 
     try std.testing.expectEqualStrings(
         \\comment


### PR DESCRIPTION
It's annoying to read snake_case for variables and fields,
and camelCase for functions and methods.
Rename everything to snake_case.

Types (generic or otherwise) will continue to use PascalCase.
