### PR TITLE
all: Revert snake_case rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
+- Revert release 0.4.0.
 - Switch support to Zig 0.12.
 
 ## 0.4.0 - 2024-01-27

--- a/src/Archive.zig
+++ b/src/Archive.zig
@@ -78,19 +78,19 @@ pub fn extract(self: Archive, alloc: std.mem.Allocator, dest: []const u8) !void 
     var dir = try std.fs.cwd().makeOpenPath(dest, .{});
     defer dir.close();
 
-    return self.extract_dir(alloc, dir);
+    return self.extractDir(alloc, dir);
 }
 
 /// Extracts all files in the Archive to the given directory.
 ///
 /// Paths in the archive are relative to the destination directory.
 /// They are not allowed to escape the destination directory with use of `../`.
-pub fn extract_dir(self: Archive, alloc: std.mem.Allocator, dir: std.fs.Dir) !void {
+pub fn extractDir(self: Archive, alloc: std.mem.Allocator, dir: std.fs.Dir) !void {
     const extractor = try Extractor.init(alloc, dir);
     defer extractor.deinit();
 
     for (self.files.items()) |file| {
-        try extractor.write_file(file);
+        try extractor.writeFile(file);
     }
 }
 

--- a/src/Iterator.zig
+++ b/src/Iterator.zig
@@ -72,7 +72,7 @@ pub fn extract(self: *Iterator, alloc: std.mem.Allocator, dest: []const u8) !voi
     var dir = try std.fs.cwd().makeOpenPath(dest, .{});
     defer dir.close();
 
-    return self.extract_dir(alloc, dir);
+    return self.extractDir(alloc, dir);
 }
 
 /// Extracts the remaining contents of an Iterator to a directory,
@@ -80,12 +80,12 @@ pub fn extract(self: *Iterator, alloc: std.mem.Allocator, dest: []const u8) !voi
 ///
 /// Paths in the archive are relative to the destination directory.
 /// They are not allowed to escape the destination directory with use of `../`.
-pub fn extract_dir(self: *Iterator, alloc: std.mem.Allocator, dir: std.fs.Dir) !void {
+pub fn extractDir(self: *Iterator, alloc: std.mem.Allocator, dir: std.fs.Dir) !void {
     const extractor = try Extractor.init(alloc, dir);
     defer extractor.deinit();
 
     while (self.next()) |file| {
-        try extractor.write_file(file);
+        try extractor.writeFile(file);
     }
 }
 

--- a/src/format.zig
+++ b/src/format.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 const File = @import("./File.zig");
 
 /// Formatter writes txtar files to a writer of the given type.
-/// Use `new_formatter` to construct a Formatter from a writer with a known type.
+/// Use `newFormatter` to construct a Formatter from a writer with a known type.
 pub fn Formatter(comptime Writer: type) type {
     return struct {
         /// Error type returned by the Formatter.
@@ -19,7 +19,7 @@ pub fn Formatter(comptime Writer: type) type {
         /// Comment, if non-null, is written at the top of the file.
         pub fn init(w: Writer, comment: ?[]const u8) Error!Self {
             if (comment) |c| if (c.len > 0) {
-                try print_ensure_nl(w, c);
+                try printEnsureNL(w, c);
             };
 
             return .{ .writer = w };
@@ -33,12 +33,12 @@ pub fn Formatter(comptime Writer: type) type {
         /// Note that the formatter does not sanitize the file name.
         /// If it contains directory traversal elements like "../",
         /// they'll be written to the txtar file as-is.
-        pub fn write_file(self: *Self, f: File) Error!void {
+        pub fn writeFile(self: *Self, f: File) Error!void {
             try self.writer.print("-- {s} --\n", .{f.name});
-            try print_ensure_nl(self.writer, f.contents);
+            try printEnsureNL(self.writer, f.contents);
         }
 
-        fn print_ensure_nl(w: Writer, s: []const u8) Error!void {
+        fn printEnsureNL(w: Writer, s: []const u8) Error!void {
             try w.print("{s}", .{s});
             if (s.len == 0 or s[s.len - 1] != '\n') {
                 try w.print("\n", .{});
@@ -57,7 +57,7 @@ test "file tests" {
         const w = buf.writer();
         var formatter = try Formatter(@TypeOf(w)).init(w, tt.comment);
         for (tt.files) |f| {
-            try formatter.write_file(f);
+            try formatter.writeFile(f);
         }
 
         const want_src = tt.canonical_src orelse tt.src;

--- a/src/txtar.zig
+++ b/src/txtar.zig
@@ -68,12 +68,12 @@
 //!
 //! ## Writing txtar files
 //!
-//! Use `new_formatter` to write txtar files to a writer.
+//! Use `newFormatter` to write txtar files to a writer.
 //!
 //! ```
 //! var file: std.fs.File = // ...
-//! var f = try txtar.new_formatter(file.writer(), "This is a comment.");
-//! try f.write_file(.{
+//! var f = try txtar.newFormatter(file.writer(), "This is a comment.");
+//! try f.writeFile(.{
 //!    .name = "foo/bar.txt",
 //!    .contents = "Hello, world!\n",
 //! });
@@ -102,8 +102,8 @@
 //! const extractor = try txtar.Extractor.init(allocator, dir);
 //! defer extractor.deinit();
 //!
-//! try extractor.write_file(txtar.File{ ... });
-//! try extractor.write_file(txtar.File{ ... });
+//! try extractor.writeFile(txtar.File{ ... });
+//! try extractor.writeFile(txtar.File{ ... });
 //! ```
 
 const std = @import("std");
@@ -117,17 +117,17 @@ pub const Extractor = @import("./Extractor.zig");
 /// Constructs a Formatter from a writer with a known type.
 ///
 /// This can be more convenient than instantiating the Formatter type directly.
-pub fn new_formatter(writer: anytype, comment: ?[]const u8) !Formatter(@TypeOf(writer)) {
+pub fn newFormatter(writer: anytype, comment: ?[]const u8) !Formatter(@TypeOf(writer)) {
     return try Formatter(@TypeOf(writer)).init(writer, comment);
 }
 
-test new_formatter {
+test newFormatter {
     var buf = std.ArrayList(u8).init(std.testing.allocator);
     defer buf.deinit();
 
-    var f = try new_formatter(buf.writer(), "comment");
-    try f.write_file(.{ .name = "foo.txt", .contents = "foo" });
-    try f.write_file(.{ .name = "bar.txt", .contents = "bar\n" });
+    var f = try newFormatter(buf.writer(), "comment");
+    try f.writeFile(.{ .name = "foo.txt", .contents = "foo" });
+    try f.writeFile(.{ .name = "bar.txt", .contents = "bar\n" });
 
     try std.testing.expectEqualStrings(
         \\comment


### PR DESCRIPTION
Match Zig's own style guide for naming
and use camelCase for function names.

This reverts commit d83f882996c3cf0fa3674d003d7a76ac2713d16e.
